### PR TITLE
🐛 Parameterize channel name and ID; Fix emote cache never updating

### DIFF
--- a/src/lib/parseEmotes.js
+++ b/src/lib/parseEmotes.js
@@ -116,7 +116,7 @@ module.exports = async function parseEmotes(message, messageEmotes = {}) {
     }
   }
   const result = (parsedMessage || message)
-    .replace(emoteRegex, (code) => `![${sources[code.toLowerCase()]} ${code}](${emotes[code.toLowerCase()]}#emote)`);
+    .replace(emoteRegex, (code) => `![${sources[code.toLowerCase()]} - ${code}](${emotes[code.toLowerCase()]}#emote)`);
   if (result === message) return undefined;
   return result;
 };

--- a/src/lib/parseEmotes.js
+++ b/src/lib/parseEmotes.js
@@ -72,7 +72,7 @@ async function get7tvEmotes() {
 }
 
 async function getEmoteRegex() {
-  if (!emoteRegex || (lastRequest && lastRequest > Date.now - emoteTimeout)) {
+  if (!emoteRegex || (lastRequest && lastRequest > Date.now() - emoteTimeout)) {
     console.log('Refreshing BTTV, 7TV and FFZ cache...');
     await Promise.all([
       getBttvEmotes(),

--- a/src/lib/parseEmotes.js
+++ b/src/lib/parseEmotes.js
@@ -19,7 +19,6 @@ const appendEmote = (selector) => (emote) => {
   regexStr += `${lowerCaseCode.replace(/\(/, '\\(').replace(/\)/, '\\)')}|`;
 };
 
-// TODO: parameterize channel name and ID
 async function getBttvEmotes() {
   let {
     data: allEmotes
@@ -29,7 +28,7 @@ async function getBttvEmotes() {
       channelEmotes,
       sharedEmotes
     }
-  } = await axios.get('https://api.betterttv.net/3/cached/users/twitch/413856795');
+  } = await axios.get(`https://api.betterttv.net/3/cached/users/twitch/${process.env.TWITCH_CHANNEL_ID}`);
   allEmotes = allEmotes.concat(channelEmotes).concat(sharedEmotes);
   const appenderizer3000 = appendEmote(({
     code,
@@ -44,7 +43,7 @@ async function getBttvEmotes() {
 
 async function getFfzEmotes() {
   const { data: { sets } } = await axios.get('https://api.frankerfacez.com/v1/set/global');
-  const { data: { sets: channelSets } } = await axios.get('https://api.frankerfacez.com/v1/room/codinggarden');
+  const { data: { sets: channelSets } } = await axios.get(`https://api.frankerfacez.com/v1/room/${process.env.TWITCH_CHANNEL_NAME}`);
   const all = sets[3].emoticons.concat(channelSets[609613].emoticons);
   const appenderizer9000 = appendEmote(({
     name: code,
@@ -59,7 +58,7 @@ async function getFfzEmotes() {
 
 async function get7tvEmotes() {
   const { data: globalEmotes } = await axios.get('https://api.7tv.app/v2/emotes/global');
-  const { data: channelEmotes } = await axios.get('https://api.7tv.app/v2/users/413856795/emotes');
+  const { data: channelEmotes } = await axios.get(`https://api.7tv.app/v2/users/${process.env.TWITCH_CHANNEL_ID}/emotes`);
   const all = globalEmotes.concat(channelEmotes);
   const appenderizer9000 = appendEmote(({
     name: code,

--- a/src/lib/parseEmotes.js
+++ b/src/lib/parseEmotes.js
@@ -72,7 +72,7 @@ async function get7tvEmotes() {
 }
 
 async function getEmoteRegex() {
-  if (!emoteRegex || (lastRequest && lastRequest > Date.now() - emoteTimeout)) {
+  if (!emoteRegex || (lastRequest && Date.now() - lastRequest > emoteTimeout)) {
     console.log('Refreshing BTTV, 7TV and FFZ cache...');
     await Promise.all([
       getBttvEmotes(),

--- a/src/services/twitch/rewards.service.js
+++ b/src/services/twitch/rewards.service.js
@@ -8,10 +8,14 @@ const {
   updateRedemption,
 } = require('../../lib/twitchAPI');
 
+const {
+  TWITCH_CHANNEL_ID: channelId
+} = process.env;
+
 class TwitchRewardsService {
   constructor(app) {
     const init_topics = [{
-      topic: 'channel-points-channel-v1.413856795',
+      topic: `channel-points-channel-v1.${channelId}`,
       token: process.env.TWITCH_REWARDS_TOKEN,
     }];
 


### PR DESCRIPTION
### `parseEmotes.js`

- Add missing `-` in third-party emote tooltip to match the Twitch emote tooltip
- Parameterize channel name and ID
- Fix emote cache never updating
  * Emote cache gets initialized but never gets updated because `lastRequest > Date.now - emoteTimeout` is always `false` (`Date.now - emoteTimeout` equals `NaN`). Fix is to call the `Date.now` function.
 ```diff
-lastRequest > Date.now - emoteTimeout
+Date.now() - lastRequest > emoteTimeout
```

### `rewards.service.js`

- Parameterize channel ID

### Possible bugs

- The FrankerFaceZ API requires the room name (aka channel name) to be in all lowercase. If the channel name specified in `.env` contains uppercase characters, the request will fail (404). This might (not) be a wanted behavior for this project.
  * **Edit**: To be fair, other parts of the code depend on the channel name being in all lowercase. This might be a separate issue on its own.